### PR TITLE
Finalize trigger files and event listener for CD pipeline

### DIFF
--- a/.tekton/events/event_listener.yaml
+++ b/.tekton/events/event_listener.yaml
@@ -1,0 +1,8 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: cd-listener
+spec:
+  serviceAccountName: pipeline
+  triggers:
+    - triggerRef: cd-trigger

--- a/.tekton/events/trigger.yaml
+++ b/.tekton/events/trigger.yaml
@@ -1,0 +1,10 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: cd-trigger
+spec:
+  serviceAccountName: pipeline
+  bindings:
+    - ref: cd-binding
+  template:
+    ref: cd-template

--- a/.tekton/events/trigger_binding.yaml
+++ b/.tekton/events/trigger_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: cd-binding
+spec:
+  params:
+  - name: git-repo-url
+    value: $(body.repository.html_url)
+  - name: git-repo-name
+    value: $(body.repository.name)
+  - name: git-revision
+    value: $(body.head_commit.id)

--- a/.tekton/events/trigger_template.yaml
+++ b/.tekton/events/trigger_template.yaml
@@ -1,0 +1,33 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: cd-template
+spec:
+  params:
+  - name: git-repo-url
+    description: The git repository url
+  - name: git-revision
+    description: The git revision
+  - name: git-repo-name
+    description: The name of the deployment to be created / patched
+
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: cd-pipeline-$(tt.params.git-repo-name)-
+    spec:
+      serviceAccountName: pipeline
+      pipelineRef:
+        name: cd-pipeline
+      params:
+      - name: APP_NAME
+        value: $(tt.params.git-repo-name)
+      - name: GIT_REPO
+        value: $(tt.params.git-repo-url)
+      - name: IMAGE_NAME
+        value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(tt.params.git-repo-name):$(tt.params.git-revision)
+      workspaces:
+      - name: pipeline-workspace
+        persistentVolumeClaim:
+          claimName: pipeline-pvc


### PR DESCRIPTION
This PR adds the initial Tekton CD pipeline to automate linting, testing, image building, and deployment for the promotions service. It includes:

pylint task definition in .tekton/tasks.yaml
Full pipeline defined in .tekton/pipeline.yaml
Persistent volume setup via .tekton/workspace.yaml
Trigger, trigger binding, template, and event listener under .tekton/events/
EventListener exposed via OpenShift route and integrated with GitHub webhook

Merging this PR allows pushes to master to automatically trigger a Tekton PipelineRun.
