### PR TITLE
Fix: map 'GIT_REPO' param to 'url' for git-clone task

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -18,6 +18,11 @@ spec:
     - name: git-clone
       taskRef:
         name: git-clone
+      params:
+        - name: url
+          value: $(params.GIT_REPO)
+        - name: revision
+          value: $(params.GIT_REF)
       workspaces:
         - name: output
           workspace: pipeline-workspace
@@ -28,3 +33,4 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
+


### PR DESCRIPTION
This PR updates the cd-pipeline definition to correctly pass the required url and revision parameters to the git-clone task. The previous configuration used GIT_REPO, which is not recognized by the official git-clone task from Tekton Hub. This fix allows the pipeline to execute the clone step successfully.