### PR TITLE
Fix: add GIT_REF param to trigger template

### DIFF
--- a/.tekton/events/trigger_template.yaml
+++ b/.tekton/events/trigger_template.yaml
@@ -4,30 +4,33 @@ metadata:
   name: cd-template
 spec:
   params:
-  - name: git-repo-url
-    description: The git repository url
-  - name: git-revision
-    description: The git revision
-  - name: git-repo-name
-    description: The name of the deployment to be created / patched
+    - name: git-repo-url
+      description: The git repository url
+    - name: git-revision
+      description: The git revision
+    - name: git-repo-name
+      description: The name of the deployment to be created / patched
 
   resourcetemplates:
-  - apiVersion: tekton.dev/v1beta1
-    kind: PipelineRun
-    metadata:
-      generateName: cd-pipeline-$(tt.params.git-repo-name)-
-    spec:
-      serviceAccountName: pipeline
-      pipelineRef:
-        name: cd-pipeline
-      params:
-      - name: APP_NAME
-        value: $(tt.params.git-repo-name)
-      - name: GIT_REPO
-        value: $(tt.params.git-repo-url)
-      - name: IMAGE_NAME
-        value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(tt.params.git-repo-name):$(tt.params.git-revision)
-      workspaces:
-      - name: pipeline-workspace
-        persistentVolumeClaim:
-          claimName: pipeline-pvc
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: cd-pipeline-$(tt.params.git-repo-name)-
+      spec:
+        serviceAccountName: pipeline
+        pipelineRef:
+          name: cd-pipeline
+        params:
+          - name: APP_NAME
+            value: $(tt.params.git-repo-name)
+          - name: GIT_REPO
+            value: $(tt.params.git-repo-url)
+          - name: GIT_REF
+            value: $(tt.params.git-revision)
+          - name: IMAGE_NAME
+            value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(tt.params.git-repo-name):$(tt.params.git-revision)
+        workspaces:
+          - name: pipeline-workspace
+            persistentVolumeClaim:
+              claimName: pipeline-pvc
+


### PR DESCRIPTION
This PR updates the TriggerTemplate to include the missing GIT_REF parameter, allowing the cd-pipeline to pass the required revision to the git-clone task. The pipeline was tested successfully in OpenShift using this branch.