### PR TITLE
feat: integrate apply-manifests deployment step into CD pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -63,25 +63,25 @@ spec:
         - name: IMAGE
           value: $(params.IMAGE_NAME)
 
-    # --- 5. deploy to cluster ----------------------------------------------
-    - name: deploy
-      taskRef:
-        name: deploy-image
+    # --- 5. deploy all k8s manifests ----------------------------------------
+    - name: deploy-manifests
       runAfter:
         - build-image
+      taskRef:
+        name: apply-manifests
       workspaces:
         - name: source
           workspace: pipeline-workspace
       params:
-        - name: image-name
-          value: $(params.IMAGE_NAME)
+        - name: manifest-dir
+          value: "k8s"
 
     # --- 6. BDD tests against deployment -----------------------------------
     - name: run-bdd
       taskRef:
         name: behave-test
       runAfter:
-        - deploy
+        - deploy-manifests
       workspaces:
         - name: source
           workspace: pipeline-workspace

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -258,3 +258,36 @@ spec:
         pip install behave requests
         echo "=== running behave tests against $BASE_URL ==="
         behave
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: apply-manifests
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Deployment
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: kubectl, deploy
+    tekton.dev/displayName: "Apply Manifests"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: Recursively apply all Kubernetes manifests from a given directory
+  params:
+    - name: manifest-dir
+      type: string
+      description: Path (relative to workspace) containing your manifests
+      default: "k8s"
+  workspaces:
+    - name: source
+      description: The git-clone workspace
+  steps:
+    - name: kubectl-apply
+      image: bitnami/kubectl:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        echo "🔄 Applying manifests from $(params.manifest-dir)..."
+        kubectl apply -R -f $(params.manifest-dir)


### PR DESCRIPTION
This PR introduces a new Tekton Task named apply-manifests that recursively applies all Kubernetes YAML files under the k8s/ directory using kubectl. It then replaces the previous custom deploy step with this generic task in our cd-pipeline, ensuring that every time we push to master, the pipeline will:

Clone the repo
Lint with pylint
Run unit tests (pytest-env)
Build and push the container image (build-and-push)
Apply all Kubernetes manifests (apply-manifests)
Execute BDD tests against the live service (behave-test)